### PR TITLE
Openapi 32

### DIFF
--- a/.changeset/itchy-corners-crash.md
+++ b/.changeset/itchy-corners-crash.md
@@ -1,0 +1,5 @@
+---
+'@appear.sh/oas-zod-validator': minor
+---
+
+Added support for 3.2 and enforced 3.1 boundaries

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 # OAS Zod Validator
 
-A robust OpenAPI Specification (OAS) validator built with Zod, providing type-safe schema validation for both OAS 3.0.x and 3.1 specifications.
+A robust OpenAPI Specification (OAS) validator built with Zod, providing type-safe schema validation for both OAS 3.0.x, 3.1, and 3.2 specifications.
 
 [![npm version](https://badge.fury.io/js/%40appear.sh%2Foas-zod-validator.svg)](https://www.npmjs.com/package/@appear.sh/oas-zod-validator)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -31,7 +31,7 @@ A robust OpenAPI Specification (OAS) validator built with Zod, providing type-sa
 
 ## Features
 
-- Full OpenAPI 3.0.x and 3.1 support
+- Full OpenAPI 3.0.x, 3.1, and 3.2 support
 - Type-safe validation using Zod
 - Detailed error messages with path information
 - Zero external runtime dependencies

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export type {
 // Re-export types that consumers might need
 export type { OpenAPIObject } from './schemas/openapi.js';
 export type { OpenAPIObject31 } from './schemas/openapi31.js';
+export type { OpenAPIObject32 } from './schemas/openapi32.js';
 
 // Export memory utilities
 export {

--- a/src/schemas/components.ts
+++ b/src/schemas/components.ts
@@ -12,7 +12,12 @@ import {
   LinkReferenceObject,
   CallbackReferenceObject,
 } from './reference.js';
-import { RequestBodyObject, ResponseObject } from './requestResponse.js';
+import {
+  RequestBodyObject,
+  ResponseObject,
+  RequestBodyObject32,
+  ResponseObject32,
+} from './requestResponse.js';
 
 // Parameter Object (reused from paths.ts to avoid circular dependency)
 const ParameterObject = z.object({
@@ -42,7 +47,37 @@ const ExampleObject = z
   })
   .refine((data) => !(data.value && data.externalValue), {
     message: "Example cannot have both 'value' and 'externalValue'",
-  });
+  })
+  .strict();
+
+// Example Object (OAS 3.2)
+const ExampleObject32 = z
+  .object({
+    summary: z.string().optional(),
+    description: z.string().optional(),
+    value: z.any().optional(),
+    dataValue: z.any().optional(),
+    serializedValue: z.any().optional(),
+    externalValue: z.string().url().optional(),
+  })
+  .refine((data) => !(data.value && data.externalValue), {
+    message: "Example cannot have both 'value' and 'externalValue'",
+  })
+  .refine(
+    (data) => {
+      const n = [
+        data.value !== undefined,
+        data.dataValue !== undefined,
+        data.serializedValue !== undefined,
+        data.externalValue !== undefined,
+      ].filter(Boolean).length;
+      return n <= 1;
+    },
+    {
+      message:
+        "Only one of 'value', 'dataValue', 'serializedValue', or 'externalValue' may be present",
+    }
+  );
 
 // Link Object
 export const LinkObject = z
@@ -137,16 +172,155 @@ export const ComponentsObject = z
 export type Components = z.infer<typeof ComponentsObject>;
 
 // 3.1 variant using SchemaObject31 for component schemas
-export const ComponentsObject31 = ComponentsObject.safeExtend({
-  schemas: z
-    .record(
-      z.string().regex(/^[a-zA-Z0-9._-]+$/, {
-        message:
-          'Schema names must contain only alphanumeric characters, dots, underscores, and hyphens',
-      }),
-      z.union([SchemaObject31, SchemaReferenceObject])
-    )
-    .optional(),
-});
+export const ComponentsObject31 = z
+  .object({
+    schemas: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/, {
+          message:
+            'Schema names must contain only alphanumeric characters, dots, underscores, and hyphens',
+        }),
+        z.union([SchemaObject31, SchemaReferenceObject])
+      )
+      .optional(),
+
+    responses: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([ResponseObject, ResponseReferenceObject])
+      )
+      .optional(),
+
+    parameters: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([ParameterObject, ParameterReferenceObject])
+      )
+      .optional(),
+
+    examples: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([ExampleObject, ExampleReferenceObject])
+      )
+      .optional(),
+
+    requestBodies: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([RequestBodyObject, RequestBodyReferenceObject])
+      )
+      .optional(),
+
+    headers: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([HeaderObject, HeaderReferenceObject])
+      )
+      .optional(),
+
+    securitySchemes: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([ReferenceObject, z.any()])
+      )
+      .optional(),
+
+    links: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([LinkObject, LinkReferenceObject])
+      )
+      .optional(),
+
+    callbacks: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([CallbackObject, CallbackReferenceObject])
+      )
+      .optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'Components object must have at least one property',
+  });
 
 export type Components31 = z.infer<typeof ComponentsObject31>;
+
+// Components Object (OAS 3.2)
+export const ComponentsObject32 = z
+  .object({
+    schemas: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/, {
+          message:
+            'Schema names must contain only alphanumeric characters, dots, underscores, and hyphens',
+        }),
+        z.union([SchemaObject31, SchemaReferenceObject])
+      )
+      .optional(),
+
+    responses: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([ResponseObject32, ResponseReferenceObject])
+      )
+      .optional(),
+
+    parameters: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([ParameterObject, ParameterReferenceObject])
+      )
+      .optional(),
+
+    examples: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([ExampleObject32, ExampleReferenceObject])
+      )
+      .optional(),
+
+    requestBodies: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([RequestBodyObject32, RequestBodyReferenceObject])
+      )
+      .optional(),
+
+    headers: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([HeaderObject, HeaderReferenceObject])
+      )
+      .optional(),
+
+    // For 3.2 we still allow either a local object or a reference; URI refs are validated elsewhere
+    securitySchemes: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([ReferenceObject, z.any()])
+      )
+      .optional(),
+
+    links: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([LinkObject, LinkReferenceObject])
+      )
+      .optional(),
+
+    callbacks: z
+      .record(
+        z.string().regex(/^[a-zA-Z0-9._-]+$/),
+        z.union([CallbackObject, CallbackReferenceObject])
+      )
+      .optional(),
+
+    // New reusable media types registry in 3.2
+    mediaTypes: z.record(z.string(), z.any()).optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'Components object must have at least one property',
+  });
+
+export type Components32 = z.infer<typeof ComponentsObject32>;

--- a/src/schemas/openapi.ts
+++ b/src/schemas/openapi.ts
@@ -39,7 +39,7 @@ export const ResponseObject = z
 
 // Add explicit type annotation to fix compiler serialization error
 export const OpenAPIObject: z.ZodType = z.object({
-  openapi: z.string().regex(/^3\.(0|1)\.\d+$/),
+  openapi: z.string().regex(/^3\.0\.\d+$/),
   info: z.object({
     title: z.string(),
     description: z.string().optional(),

--- a/src/schemas/openapi31.ts
+++ b/src/schemas/openapi31.ts
@@ -21,13 +21,14 @@ const WebhookObject = z
     head: WebhookOperationObject.optional(),
     patch: WebhookOperationObject.optional(),
     trace: WebhookOperationObject.optional(),
+    // Not part of 3.1, but we keep passthrough below to ignore unknowns
   })
   .passthrough();
 
 // Add explicit type annotation to fix compiler serialization error
 export const OpenAPIObject31: z.ZodType = z
   .object({
-    openapi: z.string().regex(/^3\.[1-9]\.\d+$/),
+    openapi: z.string().regex(/^3\.1\.\d+$/),
     info: z
       .object({
         title: z.string(),
@@ -40,3 +41,5 @@ export const OpenAPIObject31: z.ZodType = z
     components: ComponentsObject31.optional(),
   })
   .passthrough();
+
+// 3.2 now lives in openapi32.ts for clarity

--- a/src/schemas/openapi32.components.ts
+++ b/src/schemas/openapi32.components.ts
@@ -1,3 +1,0 @@
-export { ComponentsObject32 as ComponentsObject32 } from './components.js';
-
-

--- a/src/schemas/openapi32.components.ts
+++ b/src/schemas/openapi32.components.ts
@@ -1,0 +1,3 @@
+export { ComponentsObject32 as ComponentsObject32 } from './components.js';
+
+

--- a/src/schemas/openapi32.paths.ts
+++ b/src/schemas/openapi32.paths.ts
@@ -1,11 +1,36 @@
 import { z } from 'zod';
-import { ExtensibleObject } from './core.js';
+import { ExtensibleObject, SchemaObject31 } from './core.js';
 import { ReferenceObject, ParameterReferenceObject } from './reference.js';
 import { ParameterObject } from './paths.js';
-import {
-  RequestBodyObject32,
-  ResponseObject32,
-} from './requestResponse.js';
+import { RequestBodyObject32, ResponseObject32 } from './requestResponse.js';
+
+// 3.2-only parameter variant: querystring (entire query via content)
+const QuerystringParameterObject32 = z
+  .object({
+    name: z.string().min(1, { message: 'Parameter name cannot be empty' }),
+    in: z.literal('querystring'),
+    // In 3.2, schema or content may be present, but not both
+    schema: z.union([SchemaObject31, ReferenceObject]).optional(),
+    content: z.record(z.string(), z.any()).optional(),
+    description: z.string().optional(),
+    required: z.boolean().optional(),
+    deprecated: z.boolean().optional(),
+    allowEmptyValue: z.boolean().optional(),
+    style: z.string().optional(),
+    explode: z.boolean().optional(),
+    example: z.any().optional(),
+    allowReserved: z.boolean().optional(),
+  })
+  .refine((obj) => !(obj.schema && obj.content), {
+    message:
+      "Parameter in 'querystring' must not define both 'schema' and 'content'",
+    path: ['schema'],
+  });
+
+export const ParameterObject32 = z.union([
+  ParameterObject, // 3.0/3.1-compatible variants
+  QuerystringParameterObject32, // 3.2 addition
+]);
 
 // OperationObject for OAS 3.2 using 3.2 request/response shapes
 const BaseOperationObject32 = z
@@ -18,22 +43,28 @@ const BaseOperationObject32 = z
     description: z.string().optional(),
     operationId: z.string().min(1).optional(),
     parameters: z
-      .array(z.union([ParameterObject, ParameterReferenceObject]))
-      .max(50, { message: 'Too many parameters. Consider restructuring the API.' })
+      .array(z.union([ParameterObject32, ParameterReferenceObject]))
+      .max(50, {
+        message: 'Too many parameters. Consider restructuring the API.',
+      })
       .optional()
-      .refine((params) => {
-        if (!params) return true;
-        const seen = new Set<string>();
-        for (const param of params) {
-          if ('$ref' in param) continue;
-          const key = `${(param as any).in}:${(param as any).name}`;
-          if (seen.has(key)) return false;
-          seen.add(key);
+      .refine(
+        (params) => {
+          if (!params) return true;
+          const seen = new Set<string>();
+          for (const param of params) {
+            if ('$ref' in param) continue;
+            const key = `${(param as any).in}:${(param as any).name}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+          }
+          return true;
+        },
+        {
+          message:
+            'Duplicate parameters with same name and location are not allowed',
         }
-        return true;
-      }, {
-        message: 'Duplicate parameters with same name and location are not allowed',
-      }),
+      ),
     requestBody: z.union([RequestBodyObject32, ReferenceObject]).optional(),
     responses: z
       .record(
@@ -50,10 +81,12 @@ const BaseOperationObject32 = z
   .and(ExtensibleObject);
 
 type Operation32 = z.infer<typeof BaseOperationObject32>;
-export const OperationObject32: z.ZodType<Operation32> = BaseOperationObject32.refine(
-  (op) => op.responses !== undefined,
-  { message: "Operation must include a 'responses' object defining potential responses", path: ['responses'] }
-);
+export const OperationObject32: z.ZodType<Operation32> =
+  BaseOperationObject32.refine((op) => op.responses !== undefined, {
+    message:
+      "Operation must include a 'responses' object defining potential responses",
+    path: ['responses'],
+  });
 
 // PathItem for OAS 3.2
 export const PathItemObject32 = z
@@ -89,44 +122,63 @@ export const PathItemObject32 = z
       )
       .optional(),
     parameters: z
-      .array(z.union([ParameterObject, ParameterReferenceObject]))
+      .array(z.union([ParameterObject32, ParameterReferenceObject]))
       .optional()
-      .refine((params) => {
-        if (!params) return true;
-        const seen = new Set<string>();
-        for (const param of params) {
-          if ('$ref' in param) continue;
-          const key = `${(param as any).in}:${(param as any).name}`;
-          if (seen.has(key)) return false;
-          seen.add(key);
+      .refine(
+        (params) => {
+          if (!params) return true;
+          const seen = new Set<string>();
+          for (const param of params) {
+            if ('$ref' in param) continue;
+            const key = `${(param as any).in}:${(param as any).name}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+          }
+          return true;
+        },
+        {
+          message:
+            'Duplicate parameters with same name and location are not allowed at the Path Item level',
         }
-        return true;
-      }, {
-        message:
-          'Duplicate parameters with same name and location are not allowed at the Path Item level',
-      }),
+      ),
   })
   .and(ExtensibleObject)
-  .refine((pathItem) => {
-    const operations = ['get','put','post','delete','options','head','patch','trace','query'];
-    const hasStd = operations.some((op) => op in (pathItem as any));
-    const hasAdditional = typeof (pathItem as any).additionalOperations === 'object' &&
-      Object.keys((pathItem as any).additionalOperations || {}).length > 0;
-    return hasStd || hasAdditional;
-  }, { message: 'Path item must define at least one operation' });
-
-export const PathsObject32: z.ZodType<Record<string, z.infer<typeof PathItemObject32>>> = z
-  .record(
-    z
-      .string()
-      .regex(/^\//, { message: 'Path must start with forward slash' })
-      .regex(/^\/[^?#]*$/, { message: 'Path must not include query parameters or fragments' })
-      .regex(/^(?:\/[^/{}]+|\/\{[^/{}]+\})*\/?$/, {
-        message: 'Path must follow pattern of /segment or /{param} with no empty segments',
-      }),
-    PathItemObject32
+  .refine(
+    (pathItem) => {
+      const operations = [
+        'get',
+        'put',
+        'post',
+        'delete',
+        'options',
+        'head',
+        'patch',
+        'trace',
+        'query',
+      ];
+      const hasStd = operations.some((op) => op in (pathItem as any));
+      const hasAdditional =
+        typeof (pathItem as any).additionalOperations === 'object' &&
+        Object.keys((pathItem as any).additionalOperations || {}).length > 0;
+      return hasStd || hasAdditional;
+    },
+    { message: 'Path item must define at least one operation' }
   );
 
+export const PathsObject32: z.ZodType<
+  Record<string, z.infer<typeof PathItemObject32>>
+> = z.record(
+  z
+    .string()
+    .regex(/^\//, { message: 'Path must start with forward slash' })
+    .regex(/^\/[^?#]*$/, {
+      message: 'Path must not include query parameters or fragments',
+    })
+    .regex(/^(?:\/[^/{}]+|\/\{[^/{}]+\})*\/?$/, {
+      message:
+        'Path must follow pattern of /segment or /{param} with no empty segments',
+    }),
+  PathItemObject32
+);
+
 export type Paths32 = z.infer<typeof PathsObject32>;
-
-

--- a/src/schemas/openapi32.paths.ts
+++ b/src/schemas/openapi32.paths.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+import { ExtensibleObject } from './core.js';
+import { ReferenceObject, ParameterReferenceObject } from './reference.js';
+import { ParameterObject } from './paths.js';
+import {
+  RequestBodyObject32,
+  ResponseObject32,
+} from './requestResponse.js';
+
+// OperationObject for OAS 3.2 using 3.2 request/response shapes
+const BaseOperationObject32 = z
+  .object({
+    tags: z.array(z.string()).optional(),
+    summary: z
+      .string()
+      .max(120, { message: 'Summary should be concise (max 120 characters)' })
+      .optional(),
+    description: z.string().optional(),
+    operationId: z.string().min(1).optional(),
+    parameters: z
+      .array(z.union([ParameterObject, ParameterReferenceObject]))
+      .max(50, { message: 'Too many parameters. Consider restructuring the API.' })
+      .optional()
+      .refine((params) => {
+        if (!params) return true;
+        const seen = new Set<string>();
+        for (const param of params) {
+          if ('$ref' in param) continue;
+          const key = `${(param as any).in}:${(param as any).name}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+        }
+        return true;
+      }, {
+        message: 'Duplicate parameters with same name and location are not allowed',
+      }),
+    requestBody: z.union([RequestBodyObject32, ReferenceObject]).optional(),
+    responses: z
+      .record(
+        z.string().regex(/^[1-5][0-9][0-9]$|^default$/),
+        z.union([ResponseObject32, ReferenceObject])
+      )
+      .refine((responses) => Object.keys(responses).length > 0, {
+        message: 'At least one response must be defined',
+      })
+      .optional(),
+    deprecated: z.boolean().optional(),
+    security: z.array(z.record(z.string(), z.array(z.string()))).optional(),
+  })
+  .and(ExtensibleObject);
+
+type Operation32 = z.infer<typeof BaseOperationObject32>;
+export const OperationObject32: z.ZodType<Operation32> = BaseOperationObject32.refine(
+  (op) => op.responses !== undefined,
+  { message: "Operation must include a 'responses' object defining potential responses", path: ['responses'] }
+);
+
+// PathItem for OAS 3.2
+export const PathItemObject32 = z
+  .object({
+    summary: z.string().optional(),
+    description: z.string().optional(),
+    get: OperationObject32.optional(),
+    put: OperationObject32.optional(),
+    post: OperationObject32.optional(),
+    delete: OperationObject32.optional(),
+    options: OperationObject32.optional(),
+    head: OperationObject32.optional(),
+    patch: OperationObject32.optional(),
+    trace: OperationObject32.optional(),
+    query: OperationObject32.optional(),
+    additionalOperations: z.record(z.string(), OperationObject32).optional(),
+    servers: z
+      .array(
+        z.object({
+          url: z.string().url(),
+          description: z.string().optional(),
+          variables: z
+            .record(
+              z.string(),
+              z.object({
+                default: z.string(),
+                description: z.string().optional(),
+                enum: z.array(z.string()).optional(),
+              })
+            )
+            .optional(),
+        })
+      )
+      .optional(),
+    parameters: z
+      .array(z.union([ParameterObject, ParameterReferenceObject]))
+      .optional()
+      .refine((params) => {
+        if (!params) return true;
+        const seen = new Set<string>();
+        for (const param of params) {
+          if ('$ref' in param) continue;
+          const key = `${(param as any).in}:${(param as any).name}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+        }
+        return true;
+      }, {
+        message:
+          'Duplicate parameters with same name and location are not allowed at the Path Item level',
+      }),
+  })
+  .and(ExtensibleObject)
+  .refine((pathItem) => {
+    const operations = ['get','put','post','delete','options','head','patch','trace','query'];
+    const hasStd = operations.some((op) => op in (pathItem as any));
+    const hasAdditional = typeof (pathItem as any).additionalOperations === 'object' &&
+      Object.keys((pathItem as any).additionalOperations || {}).length > 0;
+    return hasStd || hasAdditional;
+  }, { message: 'Path item must define at least one operation' });
+
+export const PathsObject32: z.ZodType<Record<string, z.infer<typeof PathItemObject32>>> = z
+  .record(
+    z
+      .string()
+      .regex(/^\//, { message: 'Path must start with forward slash' })
+      .regex(/^\/[^?#]*$/, { message: 'Path must not include query parameters or fragments' })
+      .regex(/^(?:\/[^/{}]+|\/\{[^/{}]+\})*\/?$/, {
+        message: 'Path must follow pattern of /segment or /{param} with no empty segments',
+      }),
+    PathItemObject32
+  );
+
+export type Paths32 = z.infer<typeof PathsObject32>;
+
+

--- a/src/schemas/openapi32.ts
+++ b/src/schemas/openapi32.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ComponentsObject32 } from './openapi32.components.js';
+import { ComponentsObject32 } from './components.js';
 import { PathsObject32 } from './openapi32.paths.js';
 
 export const ServerObject32 = z.object({
@@ -45,6 +45,7 @@ export const OpenAPIObject32: z.ZodType = z
       })
       .passthrough(),
     jsonSchemaDialect: z.string().url().optional(),
+    webhooks: z.record(z.string(), z.record(z.string(), z.any())).optional(),
     servers: z.array(ServerObject32).optional(),
     paths: PathsObject32.optional(),
     components: ComponentsObject32.optional(),
@@ -74,6 +75,7 @@ export const OpenAPIObjectFuture: z.ZodType = z
       })
       .passthrough(),
     jsonSchemaDialect: z.string().url().optional(),
+    webhooks: z.record(z.string(), z.record(z.string(), z.any())).optional(),
     servers: z.array(ServerObject32).optional(),
     paths: PathsObject32.optional(),
     components: ComponentsObject32.optional(),

--- a/src/schemas/openapi32.ts
+++ b/src/schemas/openapi32.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import { ComponentsObject32 } from './openapi32.components.js';
+import { PathsObject32 } from './openapi32.paths.js';
+
+export const ServerObject32 = z.object({
+  url: z.string(),
+  description: z.string().optional(),
+  name: z.string().optional(),
+  variables: z
+    .record(
+      z.string(),
+      z.object({
+        enum: z.array(z.string()).optional(),
+        default: z.string(),
+        description: z.string().optional(),
+      })
+    )
+    .optional(),
+});
+
+export const TagObject32 = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    summary: z.string().optional(),
+    parent: z.string().optional(),
+    kind: z.string().optional(),
+    externalDocs: z
+      .object({
+        description: z.string().optional(),
+        url: z.string().url(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+export const OpenAPIObject32: z.ZodType = z
+  .object({
+    openapi: z.string().regex(/^3\.2\.\d+$/),
+    $self: z.string().url().optional(),
+    info: z
+      .object({
+        title: z.string(),
+        version: z.string(),
+      })
+      .passthrough(),
+    jsonSchemaDialect: z.string().url().optional(),
+    servers: z.array(ServerObject32).optional(),
+    paths: PathsObject32.optional(),
+    components: ComponentsObject32.optional(),
+    security: z.array(z.record(z.string(), z.array(z.string()))).optional(),
+    tags: z.array(TagObject32).optional(),
+    externalDocs: z
+      .object({
+        description: z.string().optional(),
+        url: z.string().url(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+export type OpenAPI32 = z.infer<typeof OpenAPIObject32>;
+
+// Future-friendly 3.x schema used only when allowFutureOASVersions is true.
+// Mirrors 3.2 structure but allows any 3.x.y in the openapi field.
+export const OpenAPIObjectFuture: z.ZodType = z
+  .object({
+    openapi: z.string().regex(/^3\.\d+\.\d+$/),
+    $self: z.string().url().optional(),
+    info: z
+      .object({
+        title: z.string(),
+        version: z.string(),
+      })
+      .passthrough(),
+    jsonSchemaDialect: z.string().url().optional(),
+    servers: z.array(ServerObject32).optional(),
+    paths: PathsObject32.optional(),
+    components: ComponentsObject32.optional(),
+    security: z.array(z.record(z.string(), z.array(z.string()))).optional(),
+    tags: z.array(TagObject32).optional(),
+    externalDocs: z
+      .object({
+        description: z.string().optional(),
+        url: z.string().url(),
+      })
+      .optional(),
+  })
+  .passthrough();

--- a/src/schemas/paths.ts
+++ b/src/schemas/paths.ts
@@ -32,6 +32,22 @@ export const ParameterObject = z.discriminatedUnion('in', [
     schema: z.union([SchemaObject, ReferenceObject]),
     allowReserved: z.boolean().optional(),
   }),
+  // OAS 3.2: Querystring parameters (entire query string via content)
+  z
+    .object({
+      ...parameterBaseFields,
+      name: z.string().min(1, { message: 'Parameter name cannot be empty' }),
+      in: z.literal('querystring'),
+      // OAS 3.2 permits using content here; we allow schema too for compatibility, but enforce mutual exclusion
+      schema: z.union([SchemaObject, ReferenceObject]).optional(),
+      content: z.record(z.string(), z.any()).optional(),
+      allowReserved: z.boolean().optional(),
+    })
+    .refine((obj) => !((obj as any).schema && (obj as any).content), {
+      message:
+        "Parameter in 'querystring' must not define both 'schema' and 'content'",
+      path: ['schema'],
+    }),
   // Header parameters
   z.object({
     ...parameterBaseFields,
@@ -143,8 +159,10 @@ export const PathItemObject = z
     head: OperationObject.optional(),
     patch: OperationObject.optional(),
     trace: OperationObject.optional(),
-    // Non-standard extension to support GraphQL-style operations
+    // OAS 3.2 adds query method officially
     query: OperationObject.optional(),
+    // OAS 3.2 additionalOperations: allow arbitrary method keys via record
+    additionalOperations: z.record(z.string(), OperationObject).optional(),
     servers: z
       .array(
         z.object({
@@ -205,7 +223,11 @@ export const PathItemObject = z
         'trace',
         'query',
       ];
-      return operations.some((op) => op in pathItem);
+      const hasStd = operations.some((op) => op in pathItem);
+      const hasAdditional =
+        typeof (pathItem as any).additionalOperations === 'object' &&
+        Object.keys((pathItem as any).additionalOperations || {}).length > 0;
+      return hasStd || hasAdditional;
     },
     {
       message: 'Path item must define at least one operation',

--- a/src/schemas/paths.ts
+++ b/src/schemas/paths.ts
@@ -32,22 +32,6 @@ export const ParameterObject = z.discriminatedUnion('in', [
     schema: z.union([SchemaObject, ReferenceObject]),
     allowReserved: z.boolean().optional(),
   }),
-  // OAS 3.2: Querystring parameters (entire query string via content)
-  z
-    .object({
-      ...parameterBaseFields,
-      name: z.string().min(1, { message: 'Parameter name cannot be empty' }),
-      in: z.literal('querystring'),
-      // OAS 3.2 permits using content here; we allow schema too for compatibility, but enforce mutual exclusion
-      schema: z.union([SchemaObject, ReferenceObject]).optional(),
-      content: z.record(z.string(), z.any()).optional(),
-      allowReserved: z.boolean().optional(),
-    })
-    .refine((obj) => !((obj as any).schema && (obj as any).content), {
-      message:
-        "Parameter in 'querystring' must not define both 'schema' and 'content'",
-      path: ['schema'],
-    }),
   // Header parameters
   z.object({
     ...parameterBaseFields,
@@ -159,10 +143,6 @@ export const PathItemObject = z
     head: OperationObject.optional(),
     patch: OperationObject.optional(),
     trace: OperationObject.optional(),
-    // OAS 3.2 adds query method officially
-    query: OperationObject.optional(),
-    // OAS 3.2 additionalOperations: allow arbitrary method keys via record
-    additionalOperations: z.record(z.string(), OperationObject).optional(),
     servers: z
       .array(
         z.object({
@@ -221,13 +201,9 @@ export const PathItemObject = z
         'head',
         'patch',
         'trace',
-        'query',
       ];
       const hasStd = operations.some((op) => op in pathItem);
-      const hasAdditional =
-        typeof (pathItem as any).additionalOperations === 'object' &&
-        Object.keys((pathItem as any).additionalOperations || {}).length > 0;
-      return hasStd || hasAdditional;
+      return hasStd;
     },
     {
       message: 'Path item must define at least one operation',
@@ -280,7 +256,6 @@ export const PathsObject: z.ZodType<
           'head',
           'patch',
           'trace',
-          'query',
         ] as const;
         for (const op of operations) {
           const operation = pathItem[op];

--- a/src/schemas/requestResponse.ts
+++ b/src/schemas/requestResponse.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { SchemaObject } from './core.js';
+import { SchemaObject, SchemaObject31 } from './core.js';
 import {
   SchemaReferenceObject,
   ResponseReferenceObject,
@@ -27,7 +27,8 @@ export const MediaTypeObject = z
             })
             .refine((obj) => !(obj.value && obj.externalValue), {
               message: "Cannot have both 'value' and 'externalValue'",
-            }),
+            })
+            .strict(),
         ])
       )
       .optional(),
@@ -35,11 +36,80 @@ export const MediaTypeObject = z
   })
   .passthrough();
 
+// Media Type Object (OAS 3.2)
+export const MediaTypeObject32 = z
+  .object({
+    schema: z.union([SchemaObject31, SchemaReferenceObject]).optional(),
+    // Streaming/sequential media support
+    itemSchema: z.union([SchemaObject31, SchemaReferenceObject]).optional(),
+    example: z.any().optional(),
+    examples: z
+      .record(
+        z.string(),
+        z.union([
+          ExampleReferenceObject,
+          z
+            .object({
+              summary: z.string().optional(),
+              description: z.string().optional(),
+              // OAS 3.2: examples can carry either structured or serialized values
+              value: z.any().optional(),
+              dataValue: z.any().optional(),
+              serializedValue: z.any().optional(),
+              externalValue: z.string().url().optional(),
+            })
+            .refine((obj) => {
+              const present = [
+                obj.value !== undefined,
+                obj.dataValue !== undefined,
+                obj.serializedValue !== undefined,
+                obj.externalValue !== undefined,
+              ].filter(Boolean).length;
+              return present <= 1;
+            }, {
+              message:
+                "Only one of 'value', 'dataValue', 'serializedValue', or 'externalValue' may be present",
+            })
+            .strict(),
+        ])
+      )
+      .optional(),
+    // Multipart extensions in 3.2
+    prefixEncoding: z.record(z.string(), z.any()).optional(),
+    itemEncoding: z.record(z.string(), z.any()).optional(),
+    // Keep legacy encoding to avoid breaking existing specs; disallow mixing via refine below
+    encoding: z.record(z.string(), z.any()).optional(),
+  })
+  .passthrough()
+  .refine(
+    (obj) => {
+      // If either prefixEncoding or itemEncoding present, discourage legacy 'encoding'
+      if ((obj as any).prefixEncoding || (obj as any).itemEncoding) {
+        return (obj as any).encoding === undefined;
+      }
+      return true;
+    },
+    {
+      message:
+        "Use 'prefixEncoding'/'itemEncoding' instead of 'encoding' for multipart media types in OAS 3.2",
+      path: ['encoding'],
+    }
+  );
+
 // Request Body Object
 export const RequestBodyObject = z
   .object({
     description: z.string().optional(),
     content: z.record(z.string(), MediaTypeObject),
+    required: z.boolean().optional(),
+  })
+  .passthrough();
+
+// Request Body Object (OAS 3.2)
+export const RequestBodyObject32 = z
+  .object({
+    description: z.string().optional(),
+    content: z.record(z.string(), MediaTypeObject32),
     required: z.boolean().optional(),
   })
   .passthrough();
@@ -89,6 +159,55 @@ export const ResponseObject = z
 export const ResponsesObject = z.record(
   z.string(), // Status Code or 'default'
   z.union([ResponseObject, ResponseReferenceObject])
+);
+
+// Response Object (OAS 3.2)
+export const ResponseObject32 = z
+  .object({
+    // 3.2: description becomes optional; add summary field
+    description: z.string().optional(),
+    summary: z.string().optional(),
+    headers: z
+      .record(
+        z.string(),
+        z.union([
+          HeaderReferenceObject,
+          z.object({
+            description: z.string().optional(),
+            required: z.boolean().optional(),
+            deprecated: z.boolean().optional(),
+            schema: z.union([SchemaObject31, SchemaReferenceObject]).optional(),
+          }),
+        ])
+      )
+      .optional(),
+    content: z.record(z.string(), MediaTypeObject32).optional(),
+    links: z
+      .record(
+        z.string(),
+        z.union([
+          LinkReferenceObject,
+          z
+            .object({
+              operationRef: z.string().optional(),
+              operationId: z.string().optional(),
+              parameters: z.record(z.string(), z.any()).optional(),
+              requestBody: z.any().optional(),
+              description: z.string().optional(),
+              server: z.any().optional(),
+            })
+            .refine((obj) => !(obj.operationRef && obj.operationId), {
+              message: "Cannot have both 'operationRef' and 'operationId'",
+            }),
+        ])
+      )
+      .optional(),
+  })
+  .passthrough();
+
+export const ResponsesObject32 = z.record(
+  z.string(),
+  z.union([ResponseObject32, ResponseReferenceObject])
 );
 
 export type RequestBody = z.infer<typeof RequestBodyObject>;

--- a/src/schemas/requestResponse.ts
+++ b/src/schemas/requestResponse.ts
@@ -58,18 +58,21 @@ export const MediaTypeObject32 = z
               serializedValue: z.any().optional(),
               externalValue: z.string().url().optional(),
             })
-            .refine((obj) => {
-              const present = [
-                obj.value !== undefined,
-                obj.dataValue !== undefined,
-                obj.serializedValue !== undefined,
-                obj.externalValue !== undefined,
-              ].filter(Boolean).length;
-              return present <= 1;
-            }, {
-              message:
-                "Only one of 'value', 'dataValue', 'serializedValue', or 'externalValue' may be present",
-            })
+            .refine(
+              (obj) => {
+                const present = [
+                  obj.value !== undefined,
+                  obj.dataValue !== undefined,
+                  obj.serializedValue !== undefined,
+                  obj.externalValue !== undefined,
+                ].filter(Boolean).length;
+                return present <= 1;
+              },
+              {
+                message:
+                  "Only one of 'value', 'dataValue', 'serializedValue', or 'externalValue' may be present",
+              }
+            )
             .strict(),
         ])
       )

--- a/src/schemas/tests/openapi_3_1_negative_compat.test.ts
+++ b/src/schemas/tests/openapi_3_1_negative_compat.test.ts
@@ -26,6 +26,59 @@ describe('OpenAPI 3.1 compatibility with 3.2-only features', () => {
     const result = validateOpenAPI(doc);
     expect(result.valid).toBe(false);
   });
+
+  test('rejects query operation method in 3.1.x', () => {
+    const doc = {
+      openapi: '3.1.1',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/q': {
+          // 3.2-only
+          query: { responses: { '200': { description: 'OK' } } },
+        },
+      },
+    } as any;
+    const result = validateOpenAPI(doc);
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects additionalOperations in 3.1.x', () => {
+    const doc = {
+      openapi: '3.1.1',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/x': {
+          // 3.2-only
+          additionalOperations: {
+            FOO: { responses: { default: { description: 'x' } } },
+          },
+        },
+      },
+    } as any;
+    const result = validateOpenAPI(doc);
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects parameter in: querystring in 3.1.x', () => {
+    const doc = {
+      openapi: '3.1.1',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/t': {
+          get: {
+            parameters: [
+              {
+                name: 'q',
+                in: 'querystring',
+                content: { 'application/json': {} },
+              },
+            ],
+            responses: { default: { description: 'x' } },
+          },
+        },
+      },
+    } as any;
+    const result = validateOpenAPI(doc);
+    expect(result.valid).toBe(false);
+  });
 });
-
-

--- a/src/schemas/tests/openapi_3_1_negative_compat.test.ts
+++ b/src/schemas/tests/openapi_3_1_negative_compat.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'vitest';
+import { validateOpenAPI } from '../validator.js';
+
+describe('OpenAPI 3.1 compatibility with 3.2-only features', () => {
+  test('rejects examples.dataValue in 3.1.x', () => {
+    const doc = {
+      openapi: '3.1.1',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/ex': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    examples: { a: { dataValue: { id: 1 } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = validateOpenAPI(doc);
+    expect(result.valid).toBe(false);
+  });
+});
+
+

--- a/src/schemas/tests/openapi_3_2.test.ts
+++ b/src/schemas/tests/openapi_3_2.test.ts
@@ -42,6 +42,45 @@ describe('OpenAPI 3.2 features', () => {
     expect(result.valid).toBe(true);
   });
 
+  test('3.2 webhooks accepted', () => {
+    const doc = {
+      openapi: '3.2.1',
+      info: { title: 'API', version: '1.0.0' },
+      webhooks: {
+        onEvent: {
+          post: { responses: { '200': { description: 'OK' } } },
+        },
+      },
+    } as any;
+    const result = validateOpenAPI(doc);
+    expect(result.valid).toBe(true);
+  });
+
+  test('MediaType encoding: mixing legacy encoding with item/prefix encoding is rejected', () => {
+    const doc = {
+      openapi: '3.2.0',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/bad': {
+          post: {
+            requestBody: {
+              content: {
+                'multipart/mixed': {
+                  itemSchema: { type: 'string' },
+                  prefixEncoding: { x: {} },
+                  encoding: { legacy: {} }, // should be rejected by refine
+                },
+              },
+            },
+            responses: { default: { description: 'x' } },
+          },
+        },
+      },
+    } as any;
+    const result = validateOpenAPI(doc);
+    expect(result.valid).toBe(false);
+  });
+
   test('allows querystring parameter with content, disallows schema+content together', () => {
     const good = {
       openapi: '3.2.0',
@@ -98,7 +137,10 @@ describe('OpenAPI 3.2 features', () => {
                 description: 'OK',
                 content: {
                   'application/jsonl': {
-                    itemSchema: { type: 'object', properties: { id: { type: 'string' } } },
+                    itemSchema: {
+                      type: 'object',
+                      properties: { id: { type: 'string' } },
+                    },
                   },
                 },
               },
@@ -177,5 +219,3 @@ describe('OpenAPI 3.2 features', () => {
     expect(validateOpenAPI(doc).valid).toBe(true);
   });
 });
-
-

--- a/src/schemas/tests/openapi_3_2.test.ts
+++ b/src/schemas/tests/openapi_3_2.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect } from 'vitest';
+import { validateOpenAPI } from '../validator.js';
+
+describe('OpenAPI 3.2 features', () => {
+  test('accepts $self and Server.name, tags metadata', () => {
+    const doc = {
+      openapi: '3.2.0',
+      $self: 'https://api.example.com/openapi.yaml',
+      info: { title: 'API', version: '1.0.0' },
+      servers: [
+        { url: 'https://api.example.com', name: 'prod' },
+        { url: 'https://staging-api.example.com', name: 'staging' },
+      ],
+      tags: [
+        { name: 'users', summary: 'User operations', kind: 'nav' },
+        { name: 'admin', parent: 'users' },
+      ],
+      paths: {},
+    };
+    const result = validateOpenAPI(doc);
+    expect(result.valid).toBe(true);
+  });
+
+  test('supports query method and additionalOperations', () => {
+    const doc = {
+      openapi: '3.2.1',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/q': {
+          query: {
+            responses: { '200': { description: 'OK' } },
+          },
+          additionalOperations: {
+            LINK: {
+              responses: { '204': { description: 'No Content' } },
+            },
+          },
+        },
+      },
+    };
+    const result = validateOpenAPI(doc);
+    expect(result.valid).toBe(true);
+  });
+
+  test('allows querystring parameter with content, disallows schema+content together', () => {
+    const good = {
+      openapi: '3.2.0',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            parameters: [
+              {
+                name: 'q',
+                in: 'querystring',
+                content: {
+                  'application/json': { schema: { type: 'object' } },
+                },
+              },
+            ],
+            responses: { default: { description: 'x' } },
+          },
+        },
+      },
+    };
+    const bad = {
+      openapi: '3.2.0',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/test': {
+          get: {
+            parameters: [
+              {
+                name: 'q',
+                in: 'querystring',
+                schema: { type: 'string' },
+                content: { 'application/json': {} },
+              },
+            ],
+            responses: { default: { description: 'x' } },
+          },
+        },
+      },
+    };
+    expect(validateOpenAPI(good).valid).toBe(true);
+    expect(validateOpenAPI(bad).valid).toBe(false);
+  });
+
+  test('MediaType itemSchema for streaming/sequential media', () => {
+    const doc = {
+      openapi: '3.2.0',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/stream': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/jsonl': {
+                    itemSchema: { type: 'object', properties: { id: { type: 'string' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(validateOpenAPI(doc).valid).toBe(true);
+  });
+
+  test('Examples allow dataValue and serializedValue (only one at a time)', () => {
+    const good = {
+      openapi: '3.2.0',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/ex': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    examples: {
+                      a: { dataValue: { id: 1 } },
+                      b: { serializedValue: '{"id":1}' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const bad = {
+      openapi: '3.2.0',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/ex': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    examples: {
+                      a: { value: { id: 1 }, dataValue: { id: 1 } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(validateOpenAPI(good).valid).toBe(true);
+    expect(validateOpenAPI(bad).valid).toBe(false);
+  });
+
+  test('Response summary allowed and description optional', () => {
+    const doc = {
+      openapi: '3.2.0',
+      info: { title: 'API', version: '1.0.0' },
+      paths: {
+        '/ok': {
+          get: {
+            responses: {
+              '200': { summary: 'No description required' },
+            },
+          },
+        },
+      },
+    };
+    expect(validateOpenAPI(doc).valid).toBe(true);
+  });
+});
+
+

--- a/src/schemas/tests/validateFromYaml.test.ts
+++ b/src/schemas/tests/validateFromYaml.test.ts
@@ -133,16 +133,21 @@ describe('YAML Validation', () => {
 
   test('validates YAML with future OpenAPI versions', () => {
     const yaml = `
-      openapi: 3.2.0
+      openapi: 3.3.0
       info:
         title: Future API
         version: 1.0.0
       paths: {}
     `;
 
-    const result = validateFromYaml(yaml, { allowFutureOASVersions: true });
-    expect(result.valid).toBe(true);
-    expect(result.errors).toBeUndefined();
+    const result1 = validateFromYaml(yaml, {
+      allowFutureOASVersions: true,
+      strict: true,
+    });
+    const result2 = validateFromYaml(yaml, { allowFutureOASVersions: true });
+
+    expect(result1.valid).toBe(true);
+    expect(result2.valid).toBe(true);
   });
 
   test('handles YAML parsing errors', () => {
@@ -180,7 +185,7 @@ describe('YAML Validation', () => {
 
   test('validates YAML with validation options', () => {
     const yaml = `
-      openapi: 3.2.0
+      openapi: 3.3.0
       info:
         title: Future API
         version: 1.0.0

--- a/src/schemas/tests/validator.test.ts
+++ b/src/schemas/tests/validator.test.ts
@@ -389,7 +389,7 @@ describe('OpenAPI Validator', () => {
 
   test('allows future versions with allowFutureOASVersions flag', () => {
     const futureSpec = {
-      openapi: '3.2.0',
+      openapi: '3.3.0',
       info: {
         title: 'Future API',
         version: '1.0.0',
@@ -452,7 +452,7 @@ describe('OpenAPI Validator', () => {
 describe('OpenAPI Version Detection', () => {
   test('handles future 3.x versions with allowFutureOASVersions', () => {
     const futureSpec = {
-      openapi: '3.2.0',
+      openapi: '3.3.0',
       info: { title: 'Future API', version: '1.0.0' },
       paths: {},
     };
@@ -466,7 +466,7 @@ describe('OpenAPI Version Detection', () => {
 
   test('rejects future versions without allowFutureOASVersions', () => {
     const futureSpec = {
-      openapi: '3.2.0',
+      openapi: '3.3.0',
       info: { title: 'Future API', version: '1.0.0' },
       paths: {},
     };
@@ -626,7 +626,7 @@ describe('Version Detection', () => {
   });
 
   test('rejects invalid versions', () => {
-    ['2.0', '4.0.0', '3.2.0', 'invalid'].forEach((version) => {
+    ['2.0', '4.0.0', '3.3.0', 'invalid'].forEach((version) => {
       const doc = {
         openapi: version,
         info: { title: 'Test API', version: '1.0.0' },

--- a/src/schemas/validator.ts
+++ b/src/schemas/validator.ts
@@ -32,8 +32,7 @@ import {
 import { Range, LocatedZodIssue } from '../types/location.js';
 import { getByPointer } from '../utils/jsonPointer.js';
 import { createJSONPointer, JSONPointer } from '../types/index.js';
-import { ParameterObject as ParameterObjectSchema } from './paths.js';
-import { ReferenceObject as ReferenceObjectSchema } from './reference.js';
+// Decouple validator parameter resolution from Zod schemas to avoid version coupling
 
 /**
  * Options for validating OpenAPI specifications
@@ -705,13 +704,19 @@ export function validateOpenAPI(
       });
 
     if (error instanceof z.ZodError) {
-      const baseIssues = normalizeIssues(
+      let baseIssues = normalizeIssues(
         (error as z.ZodError).issues as z.ZodIssue[]
       );
-      const extraStrictIssues = options.strict
-        ? validateTagUniqueness(document as any as OpenAPISlice)
-        : [];
-      const normalized = new z.ZodError([...baseIssues, ...extraStrictIssues]);
+      // Maintain historical behaviour: if strict and parse failed early, still report tag uniqueness issues
+      if (options.strict) {
+        const tagIssues = validateTagUniqueness(
+          document as any as OpenAPISlice
+        );
+        if (tagIssues.length > 0) {
+          baseIssues = [...baseIssues, ...tagIssues];
+        }
+      }
+      const normalized = new z.ZodError(baseIssues);
       result = {
         valid: false,
         errors: normalized,
@@ -1053,18 +1058,14 @@ function validateOperationIdUniqueness(
   return issues;
 }
 
-// Type for a fully resolved Parameter object (no $ref)
-// This infers the type from the Zod schema, excluding the possibility of it being a reference itself.
-// We assume ParameterObjectSchema does not include `$ref` at its top level after specific discriminated union parsing.
-type ResolvedParameter = z.infer<typeof ParameterObjectSchema>;
+// Minimal resolved parameter shape used for uniqueness checks
+type ResolvedParameter = {
+  name: string;
+  in: string;
+} & Record<string, unknown>;
 
-// Type for an item in a parameters array, which can be a ParameterObject or a ReferenceObject
-const _ParameterOrReferenceSchema = z.union([
-  ParameterObjectSchema,
-  ReferenceObjectSchema,
-]);
-
-type ParameterOrReference = z.infer<typeof _ParameterOrReferenceSchema>;
+// Parameter or $ref shorthand for internal checks
+type ParameterOrReference = { $ref: string } | ResolvedParameter;
 
 /**
  * Checks a list of RESOLVED parameters for uniqueness based on 'name' and 'in'.
@@ -1144,12 +1145,20 @@ function collectAndValidateOperationParameters(
     doc: OpenAPISpec
   ): ResolvedParameter | null => {
     if (!('$ref' in paramOrRef)) {
-      // It's already a ParameterObject, ensure it fits our ResolvedParameter type definition
-      // ParameterObjectSchema.parse(paramOrRef); // This would throw if invalid, which is good
-      return paramOrRef as ResolvedParameter; // Assuming it's already valid if not a ref
+      // Guard minimal fields
+      const p = paramOrRef as any;
+      if (
+        p &&
+        typeof p === 'object' &&
+        typeof p.name === 'string' &&
+        typeof p.in === 'string'
+      ) {
+        return p as ResolvedParameter;
+      }
+      return null;
     }
 
-    const refString = paramOrRef.$ref;
+    const refString: string = (paramOrRef as { $ref: string }).$ref;
     let jsonPointer: JSONPointer;
     try {
       jsonPointer = createJSONPointer(refString);
@@ -1164,14 +1173,16 @@ function collectAndValidateOperationParameters(
       doc as Record<string, unknown>
     );
     if (cachedTarget !== undefined) {
-      try {
-        // Validate that the cached target is a valid ParameterObject
-        ParameterObjectSchema.parse(cachedTarget);
-        return cachedTarget as ResolvedParameter;
-      } catch {
-        // Cached item is not a valid parameter object
-        return null;
+      const ct: any = cachedTarget;
+      if (
+        ct &&
+        typeof ct === 'object' &&
+        typeof ct.name === 'string' &&
+        typeof ct.in === 'string'
+      ) {
+        return ct as ResolvedParameter;
       }
+      return null;
     }
 
     // If not in cache, resolve using lodash.get
@@ -1185,20 +1196,21 @@ function collectAndValidateOperationParameters(
       return null;
     }
 
-    try {
-      // Validate that the resolved target is a valid ParameterObject
-      ParameterObjectSchema.parse(target);
-      // Cache the successfully resolved and validated parameter object
+    const t: any = target;
+    if (
+      t &&
+      typeof t === 'object' &&
+      typeof t.name === 'string' &&
+      typeof t.in === 'string'
+    ) {
       cache.setRefTarget(
         jsonPointer,
         doc as Record<string, unknown>,
-        target as Record<string, unknown>
+        t as Record<string, unknown>
       );
-      return target as ResolvedParameter;
-    } catch {
-      // Resolved item is not a valid parameter object
-      return null;
+      return t as ResolvedParameter;
     }
+    return null;
   };
 
   const resolvedPathItemParams: ResolvedParameter[] = [];

--- a/src/schemas/validator.ts
+++ b/src/schemas/validator.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { OpenAPIObject } from './openapi.js';
 import { OpenAPIObject31 } from './openapi31.js';
+import { OpenAPIObject32, OpenAPIObjectFuture } from './openapi32.js';
 import { verifyRefTargets } from '../utils/refResolver.js';
 import { OpenAPISpec, PathItem, Operation, OpenAPISlice } from './types.js';
 import {
@@ -111,6 +112,9 @@ function _detectOpenAPIVersion(doc: Record<string, unknown>): OpenAPIVersion {
   }
 
   try {
+    if (doc.openapi.startsWith('3.2.')) {
+      return createOpenAPIVersion(doc.openapi);
+    }
     if (doc.openapi.startsWith('3.1.')) {
       return createOpenAPIVersion(doc.openapi);
     }
@@ -401,13 +405,19 @@ export function validateOpenAPI(
       typeof docAsObject.openapi === 'string' &&
       docAsObject.openapi.startsWith('3.')
     ) {
-      parsed = OpenAPIObject31.parse(
+      // Use a future-friendly 3.x schema that mirrors 3.2
+      parsed = OpenAPIObjectFuture.parse(
         docAsObject,
         parseParams
       ) as unknown as OpenAPISpec;
     } else {
       const version = detectOpenAPIVersion(docAsObject as any);
-      if (version.startsWith('3.1')) {
+      if (version.startsWith('3.2')) {
+        parsed = OpenAPIObject32.parse(
+          docAsObject as any,
+          parseParams
+        ) as unknown as OpenAPISpec;
+      } else if (version.startsWith('3.1')) {
         parsed = OpenAPIObject31.parse(
           docAsObject as any,
           parseParams
@@ -537,6 +547,8 @@ export function validateOpenAPI(
             'head',
             'patch',
             'trace',
+            // 3.2 additions
+            'query',
           ] as const;
           for (const method of methods) {
             const operation = pathItem[method]; // Operation type is already { parameters?: ... }
@@ -549,6 +561,49 @@ export function validateOpenAPI(
                 pathItem.parameters as ParameterOrReference[] | undefined,
                 operation.parameters as ParameterOrReference[] | undefined,
                 parsed, // The full document, used by resolveParameter
+                options
+              );
+              if (parameterValIssues.length > 0) {
+                allStrictIssues.push(...parameterValIssues);
+                if (options.failFast) {
+                  throw new SchemaValidationError(
+                    'Strict OpenAPI validation failed.',
+                    new z.ZodError(allStrictIssues),
+                    { context: { strict: true } }
+                  );
+                }
+                if (
+                  typeof options.maxErrors === 'number' &&
+                  options.maxErrors > 0 &&
+                  allStrictIssues.length >= options.maxErrors
+                ) {
+                  throw new SchemaValidationError(
+                    'Strict OpenAPI validation failed.',
+                    new z.ZodError(allStrictIssues),
+                    { context: { strict: true } }
+                  );
+                }
+              }
+            }
+          }
+          // 3.2 additionalOperations iteration
+          if (
+            typeof (pathItem as any).additionalOperations === 'object' &&
+            (pathItem as any).additionalOperations
+          ) {
+            for (const [methodKey, operation] of Object.entries(
+              (pathItem as any).additionalOperations as Record<string, any>
+            )) {
+              if (!operation || typeof operation !== 'object') continue;
+              checkAbort();
+              const parameterValIssues = collectAndValidateOperationParameters(
+                pathKey,
+                methodKey,
+                pathItem.parameters as ParameterOrReference[] | undefined,
+                (operation as any).parameters as
+                  | ParameterOrReference[]
+                  | undefined,
+                parsed,
                 options
               );
               if (parameterValIssues.length > 0) {


### PR DESCRIPTION
Added support to 3.2, ensuring good test coverage and a clear distinction from 3.1 are made.
Updated readme.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds full OAS 3.2 support (schemas, validator, tests) while tightening 3.0/3.1 boundaries and future 3.x handling.
> 
> - **OpenAPI 3.2 Support**:
>   - Add `openapi32.ts` and `openapi32.paths.ts` with `OpenAPIObject32`, `PathsObject32`, `PathItemObject32`, and `OperationObject32` (incl. `query`, `additionalOperations`).
>   - Introduce 3.2 components/requests/responses: `ComponentsObject32` (incl. `mediaTypes`), `RequestBodyObject32`, `ResponseObject32` (optional `description`, `summary`), `MediaTypeObject32` (`itemSchema`, `prefixEncoding`/`itemEncoding` with refine), `ExampleObject32` (`dataValue`/`serializedValue`, mutual exclusivity).
>   - Add `OpenAPIObjectFuture` for `allowFutureOASVersions` (accept any `3.x.y`).
> - **Version Boundaries**:
>   - Enforce `openapi` regexes: `openapi.ts` to `^3.0.x$`, `openapi31.ts` to `^3.1.x$`; 3.2 parsed by new schema.
> - **Validator**:
>   - Detect and parse 3.2 via `OpenAPIObject32`; use `OpenAPIObjectFuture` when `allowFutureOASVersions`.
>   - Include 3.2 ops (`query`, `additionalOperations`) in strict parameter checks; decouple parameter resolution from Zod types; improve error aggregation in strict mode.
> - **Paths/Components (3.0/3.1)**:
>   - Remove nonstandard `query` from 3.0/3.1 `PathItemObject`; keep "at least one operation" check to standard methods.
>   - Tighten `ExampleObject` with `.strict()`; rework `ComponentsObject31` to explicit object.
> - **Exports**:
>   - Export `OpenAPIObject32` type in `src/index.ts`.
> - **Tests**:
>   - Add comprehensive 3.2 tests and 3.1 negative-compat tests; update "future version" tests to `3.3.0`; extend YAML/validator tests.
> - **Docs/Release**:
>   - Update `README.md` to claim 3.2 support.
>   - Add changeset (minor).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25531c84de6adcf92d6a7db207005ae0344341cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->